### PR TITLE
AUTO-912 add socket flush and explicit timeout on write

### DIFF
--- a/current/src/urg_tcpclient.c
+++ b/current/src/urg_tcpclient.c
@@ -272,6 +272,13 @@ int tcpclient_read(urg_tcpclient_t* cli,
 
 int tcpclient_write(urg_tcpclient_t* cli, const char* buf, int size)
 {
+    // set a 1 second timeout
+    const int timeout = 1;
+    struct timeval tv;
+    tv.tv_sec = timeout / 1000; // millisecond to seccond
+    tv.tv_usec = (timeout % 1000) * 1000; // millisecond to microsecond
+    setsockopt(cli->sock_desc, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(struct timeval));
+
     // blocking if data size is larger than system's buffer.
     return send(cli->sock_desc, buf, size, 0);  //4th arg 0: no flag
 }


### PR DESCRIPTION
This PR adds two reliability fixes to the urg_c library. 

- clear_urg_communication_buffer: this will read clear the socket buffer of any extranous data before starting to stream scan data. This covers any cases where the sensor may not have been closed properly previously or the socket buffer still has some data (from a fast reconnect).
- explicitly set a 1 second timeout every time write is called. This ensures the timeout is always reset. 