### PR TITLE
AUTO-964 added ignore checksum parameter

### DIFF
--- a/current/include/urg_c/urg_sensor.h
+++ b/current/include/urg_c/urg_sensor.h
@@ -98,6 +98,7 @@ extern "C" {
         int received_skip_step;
         urg_range_data_byte_t received_range_data_byte;
         int is_sending;
+        int ignore_checksum;
 
         urg_error_handler error_handler;
 
@@ -146,7 +147,7 @@ extern "C" {
     */
     extern int urg_open(urg_t *urg, urg_connection_type_t connection_type,
                         const char *device_or_address,
-                        long baudrate_or_port);
+                        long baudrate_or_port, int ignore_checksum);
 
 
     /*!

--- a/current/samples/open_urg_sensor.c
+++ b/current/samples/open_urg_sensor.c
@@ -41,7 +41,7 @@ int open_urg_sensor(urg_t *urg, int argc, char *argv[])
     }
 
     // \~japanese Ú‘±
-    if (urg_open(urg, connection_type, device, baudrate_or_port) < 0) {
+    if (urg_open(urg, connection_type, device, baudrate_or_port, 0) < 0) {
         printf("urg_open: %s, %ld: %s\n",
             device, baudrate_or_port, urg_error(urg));
         return -1;


### PR DESCRIPTION
[JIRA-LINK](https://dexory.atlassian.net/browse/AUTO-964)

This PR adds an ignore_checksum parameter to the library allowing checksum validation to be skipped. This is to workaround an issue with the calculation of the checksum being done on the device side.

As a quick test to see if the param is working you can add a print to the calculate checksum function in `urg_sensor.c`

```
//! チェックサムの計算
static char scip_checksum(const char buffer[], int size)
{
    printf("calculating checksum");
    unsigned char sum = 0x00;
    int i;

    for (i = 0; i < size; ++i) {
        sum += buffer[i];
    }

    // 計算の意味は SCIP 仕様書を参照のこと
    return (sum & 0x3f) + 0x30;
}
```

